### PR TITLE
fix: use macos runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
           path: ${{ env.ROOTLESS_DEB_PATH }}
 
   build-ipa:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     needs: build-tweak
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-tweak:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
 
     steps:
       - name: Checkout code
@@ -97,9 +97,6 @@ jobs:
         with:
           merge-multiple: true
 
-      - name: Install dependencies
-        run: sudo apt update && sudo apt install libplist-utils xmlstarlet libxml2-utils -y
-
       - name: Download and Unzip Orion
         run: |
           curl -L -o Orion.zip $(curl -s https://api.github.com/repos/theos/orion/releases/latest | jq -r '.assets[0].browser_download_url')
@@ -113,7 +110,7 @@ jobs:
       - name: Download IPA patcher
         working-directory: patcher
         run: |
-          curl -L -o patcher https://github.com/amsyarasyiq/bunny-ipa-patcher/releases/download/release-pyon/patcher.linux-amd64
+          curl -L -o patcher https://github.com/amsyarasyiq/bunny-ipa-patcher/releases/download/release-pyon/patcher.macos-arm64
           chmod +x patcher
 
       - name: Download IPA icons

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
           path: ${{ env.ROOTLESS_DEB_PATH }}
 
   build-ipa:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     needs: build-tweak
 
     steps:
@@ -153,7 +153,7 @@ jobs:
             path: ${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa
 
   release-app:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     needs: build-ipa
     permissions:
       contents: write
@@ -200,7 +200,7 @@ jobs:
 
   app-repo:
     continue-on-error: true
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     needs: release-app
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
             
 jobs:
   build-tweak:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
 
     steps:
       - name: Checkout code
@@ -97,9 +97,6 @@ jobs:
         with:
           merge-multiple: true
 
-      - name: Install dependencies
-        run: sudo apt update && sudo apt install libplist-utils xmlstarlet libxml2-utils -y
-
       - name: Download and Unzip Orion
         run: |
           curl -L -o Orion.zip $(curl -s https://api.github.com/repos/theos/orion/releases/latest | jq -r '.assets[0].browser_download_url')
@@ -115,7 +112,7 @@ jobs:
       - name: Download IPA patcher
         working-directory: patcher
         run: |
-          curl -L -o patcher https://github.com/amsyarasyiq/bunny-ipa-patcher/releases/download/release-pyon/patcher.linux-amd64
+          curl -L -o patcher https://github.com/amsyarasyiq/bunny-ipa-patcher/releases/download/release-pyon/patcher.macos-arm64
           chmod +x patcher
 
       - name: Download IPA icons
@@ -181,13 +178,10 @@ jobs:
         with:
           merge-multiple: true
 
-      - name: Install dependencies
-        run: sudo apt update && sudo apt install libplist-utils xmlstarlet libxml2-utils -y
-
       - name: Extract Discord Version
         run: |
           unzip -q ${{ env.APP_NAME }}.ipa
-          DISCORD_VERSION=$(xmllint --xpath 'string(//key[. = "CFBundleShortVersionString"]/following-sibling::string[1])' Payload/Discord.app/Info.plist)
+          DISCORD_VERSION=$(plutil -p Payload/Discord.app/Info.plist | grep CFBundleShortVersionString | cut -d '"' -f 4)
           echo "DISCORD_VERSION=$DISCORD_VERSION" >> $GITHUB_ENV
 
       - name: Create GitHub Release
@@ -221,13 +215,10 @@ jobs:
         with:
           name: ipa
 
-      - name: Install dependencies
-        run: sudo apt update && sudo apt install libplist-utils xmlstarlet libxml2-utils -y
-        
       - name: Update app-repo.json
         run: |
           unzip -q ${{ env.APP_NAME }}.ipa
-          VERSION=$(xmllint --xpath 'string(//key[. = "CFBundleShortVersionString"]/following-sibling::string[1])' Payload/Discord.app/Info.plist)
+          VERSION=$(plutil -p Payload/Discord.app/Info.plist | grep CFBundleShortVersionString | cut -d '"' -f 4)
           DATE=$(date -u +"%Y-%m-%d")
           IPA_SIZE=$(ls -l ${{ env.APP_NAME }}.ipa | awk '{print $5}')
           DOWNLOAD_URL=https://github.com/${{ github.repository }}/releases/download/v$VERSION/${{ env.APP_NAME }}.ipa


### PR DESCRIPTION
changes all jobs back to use macOS Sonoma runners because apparently azule 50/50 silently corrupts the cydia substrate info.plist when running on regular linux
https://github.com/Al4ise/Azule/issues/144