### PR TITLE
refactor: fix gh cli exit code 1 & use pyzule instead of azule and patcher

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,19 +115,12 @@ jobs:
       - name: Download Discord IPA
         run: |
           curl -L -o discord.ipa ${{ github.event.inputs.ipa_url }}
-      - name: Make patcher directory
-        run: mkdir patcher
-
-      - name: Download IPA patcher
-        working-directory: patcher
-        run: |
-          curl -L -o patcher https://github.com/amsyarasyiq/bunny-ipa-patcher/releases/download/release-pyon/patcher.mac-amd64
-          chmod +x patcher
 
       - name: Download IPA icons
         working-directory: patcher
         run: |
           curl -L -o ipa-icons.zip https://raw.githubusercontent.com/pyoncord/assets/main/ipa-icons.zip
+          unzip ipa-icons.zip
 
       - name: Extract Values
         run: |
@@ -142,16 +135,8 @@ jobs:
         run: |
           mkdir -p ${{ github.workspace }}/build
           bash -c "$(curl https://raw.githubusercontent.com/asdfzxcvbn/pyzule/main/install-pyzule.sh)"
-          pyzule -t -i discord.ipa -o ${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa -f $(find ${{ github.workspace }} -name 'dev.theos.orion14_*_iphoneos-arm.deb' | head -n 1) ${{ github.workspace }}/${{ env.DEB_FILE_NAME }}
+          pyzule -n ${{ env.APP_NAME }} -k PyoncordIcon60x60@2x.png -d -t -i discord.ipa -o ${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa -f $(find ${{ github.workspace }} -name 'dev.theos.orion14_*_iphoneos-arm.deb' | head -n 1) ${{ github.workspace }}/${{ env.DEB_FILE_NAME }}
 
-      - name: Patch Discord
-        working-directory: patcher
-        run : |
-          ./patcher \
-            -d ${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa \
-            -o ${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa \
-            -i ./ipa-icons.zip
-  
       - name: Upload ipa as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           mkdir -p ${{ github.workspace }}/build
           bash -c "$(curl https://raw.githubusercontent.com/asdfzxcvbn/pyzule/main/install-pyzule.sh)"
-          pyzule -n ${{ env.APP_NAME }} -k PyoncordIcon60x60@2x.png -d -t -i discord.ipa -o ${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa -f $(find ${{ github.workspace }} -name 'dev.theos.orion14_*_iphoneos-arm.deb' | head -n 1) ${{ github.workspace }}/${{ env.DEB_FILE_NAME }}
+          pyzule -n ${{ env.APP_NAME }} -k PyoncordIcon60x60@2x.png -d -i discord.ipa -o ${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa -f $(find ${{ github.workspace }} -name 'dev.theos.orion14_*_iphoneos-arm.deb' | head -n 1) ${{ github.workspace }}/${{ env.DEB_FILE_NAME }}
 
       - name: Upload ipa as artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,32 +24,22 @@ jobs:
 
       - name: Download Tweak
         run: |
-          set -e
+          set +e
           
           release_info=$(gh api --header 'Accept: application/vnd.github+json' repos/${{ github.repository }}/releases/latest)
           status_code=$(echo $release_info | jq -r ".status")
-           if [ "$status_code" = "404" ]; then
+          
+          if [ "$status_code" != "null" ]; then
             echo "No releases found or request failed, status code: $status_code"
             echo "DEB_DOWNLOADED=false" >> $GITHUB_ENV
             exit 0
-          elif [ "$status_code" = "401" ]; then
-            echo "Unauthorized. Check your GitHub token."
-            exit 0
-          elif [ "$status_code" = "403" ]; then
-            echo "Forbidden. Insufficient permissions."
-            exit 0
-          elif [ "$status_code" = "422" ]; then
-            echo "Unprocessable Entity. Check request payload."
-            exit 0
-          elif [ "${status_code:0:1}" = "5" ]; then
-            echo "Server Error. GitHub API is unavailable."
-            exit 0
-          else
-            echo "Unknown error. Status code: $status_code"
-            exit 0
           fi
+
+          set -e
+
           release_version=$(echo "$release_info" | jq -r '.assets[] | select(.name | contains("iphoneos-arm.deb")) | .name' | grep -o '_[0-9.]\+_' | tr -d '_')
           control_version=$(grep '^Version:' control | cut -d ' ' -f 2)
+          
           if [ "$release_version" = "$control_version" ]; then
             echo "Versions match. Downloading DEB files..."
             echo "$release_info" | jq -r '.assets[] | select(.name | endswith(".deb")) | .browser_download_url' | xargs -I {} curl -L -O {}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,6 @@ jobs:
           curl -L -o discord.ipa ${{ github.event.inputs.ipa_url }}
 
       - name: Download IPA icons
-        working-directory: patcher
         run: |
           curl -L -o ipa-icons.zip https://raw.githubusercontent.com/pyoncord/assets/main/ipa-icons.zip
           unzip ipa-icons.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,24 @@ jobs:
           
           release_info=$(gh api --header 'Accept: application/vnd.github+json' repos/${{ github.repository }}/releases/latest)
           status_code=$(echo $release_info | jq -r ".status")
-          if [ "$status_code" != "null" ]; then
+           if [ "$status_code" = "404" ]; then
             echo "No releases found or request failed, status code: $status_code"
             echo "DEB_DOWNLOADED=false" >> $GITHUB_ENV
+            exit 0
+          elif [ "$status_code" = "401" ]; then
+            echo "Unauthorized. Check your GitHub token."
+            exit 0
+          elif [ "$status_code" = "403" ]; then
+            echo "Forbidden. Insufficient permissions."
+            exit 0
+          elif [ "$status_code" = "422" ]; then
+            echo "Unprocessable Entity. Check request payload."
+            exit 0
+          elif [ "${status_code:0:1}" = "5" ]; then
+            echo "Server Error. GitHub API is unavailable."
+            exit 0
+          else
+            echo "Unknown error. Status code: $status_code"
             exit 0
           fi
           release_version=$(echo "$release_info" | jq -r '.assets[] | select(.name | contains("iphoneos-arm.deb")) | .name' | grep -o '_[0-9.]\+_' | tr -d '_')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,9 +136,8 @@ jobs:
       - name: Inject tweak
         run: |
           mkdir -p ${{ github.workspace }}/build
-          git clone https://github.com/Al4ise/Azule.git
-          ./Azule/azule -i discord.ipa -o ${{ github.workspace }}/build -f $(find ${{ github.workspace }} -name 'dev.theos.orion14_*_iphoneos-arm.deb' | head -n 1) ${{ github.workspace }}/${{ env.DEB_FILE_NAME }}
-          mv "${{ github.workspace }}/build/"*.ipa "${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa"
+          bash -c "$(curl https://raw.githubusercontent.com/asdfzxcvbn/pyzule/main/install-pyzule.sh)"
+          pyzule -t -i discord.ipa -o ${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa -f $(find ${{ github.workspace }} -name 'dev.theos.orion14_*_iphoneos-arm.deb' | head -n 1) ${{ github.workspace }}/${{ env.DEB_FILE_NAME }}
 
       - name: Patch Discord
         working-directory: patcher

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,12 +132,11 @@ jobs:
 
       - name: Inject tweak
         run: |
-          mkdir -p ${{ github.workspace }}/build
           bash -c "$(curl https://raw.githubusercontent.com/asdfzxcvbn/pyzule/main/install-pyzule.sh)"
-          pyzule -n ${{ env.APP_NAME }} -k PyoncordIcon60x60@2x.png -d -i discord.ipa -o ${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa -f $(find ${{ github.workspace }} -name 'dev.theos.orion14_*_iphoneos-arm.deb' | head -n 1) ${{ github.workspace }}/${{ env.DEB_FILE_NAME }}
+          pyzule -n ${{ env.APP_NAME }} -k PyoncordIcon60x60@2x.png -d -i discord.ipa -o ${{ github.workspace }}/${{ env.APP_NAME }}.ipa -f $(find ${{ github.workspace }} -name 'dev.theos.orion14_*_iphoneos-arm.deb' | head -n 1) ${{ github.workspace }}/${{ env.DEB_FILE_NAME }}
 
       - name: Upload ipa as artifact
         uses: actions/upload-artifact@v4
         with:
             name: ipa
-            path: ${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa
+            path: ${{ github.workspace }}/${{ env.APP_NAME }}.ipa

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,15 +134,14 @@ jobs:
 
       - name: Inject tweak
         run: |
-          mkdir -p ${{ github.workspace }}/build
           bash -c "$(curl https://raw.githubusercontent.com/asdfzxcvbn/pyzule/main/install-pyzule.sh)"
-          pyzule -n ${{ env.APP_NAME }} -k PyoncordIcon60x60@2x.png -d -i discord.ipa -o ${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa -f $(find ${{ github.workspace }} -name 'dev.theos.orion14_*_iphoneos-arm.deb' | head -n 1) ${{ github.workspace }}/${{ env.DEB_FILE_NAME }}
+          pyzule -n ${{ env.APP_NAME }} -k PyoncordIcon60x60@2x.png -d -i discord.ipa -o ${{ github.workspace }}/${{ env.APP_NAME }}.ipa -f $(find ${{ github.workspace }} -name 'dev.theos.orion14_*_iphoneos-arm.deb' | head -n 1) ${{ github.workspace }}/${{ env.DEB_FILE_NAME }}
 
       - name: Upload ipa as artifact
         uses: actions/upload-artifact@v4
         with:
             name: ipa
-            path: ${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa
+            path: ${{ github.workspace }}/${{ env.APP_NAME }}.ipa
 
   release-app:
     runs-on: macos-14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,6 @@ jobs:
           curl -L -o discord.ipa ${{ github.event.inputs.ipa_url }}
 
       - name: Download IPA icons
-        working-directory: patcher
         run: |
           curl -L -o ipa-icons.zip https://raw.githubusercontent.com/pyoncord/assets/main/ipa-icons.zip
           unzip ipa-icons.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,9 +139,8 @@ jobs:
       - name: Inject tweak
         run: |
           mkdir -p ${{ github.workspace }}/build
-          git clone https://github.com/Al4ise/Azule.git
-          ./Azule/azule -i discord.ipa -o ${{ github.workspace }}/build -f $(find ${{ github.workspace }} -name 'dev.theos.orion14_*_iphoneos-arm.deb' | head -n 1) ${{ github.workspace }}/${{ env.DEB_FILE_NAME }}
-          mv "${{ github.workspace }}/build/"*.ipa "${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa"
+          bash -c "$(curl https://raw.githubusercontent.com/asdfzxcvbn/pyzule/main/install-pyzule.sh)"
+          pyzule -t -i discord.ipa -o ${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa -f $(find ${{ github.workspace }} -name 'dev.theos.orion14_*_iphoneos-arm.deb' | head -n 1) ${{ github.workspace }}/${{ env.DEB_FILE_NAME }}
 
       - name: Patch Discord
         working-directory: patcher

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,19 +116,11 @@ jobs:
         run: |
           curl -L -o discord.ipa ${{ github.event.inputs.ipa_url }}
 
-      - name: Make patcher directory
-        run: mkdir patcher
-
-      - name: Download IPA patcher
-        working-directory: patcher
-        run: |
-          curl -L -o patcher https://github.com/amsyarasyiq/bunny-ipa-patcher/releases/download/release-pyon/patcher.mac-amd64
-          chmod +x patcher
-
       - name: Download IPA icons
         working-directory: patcher
         run: |
           curl -L -o ipa-icons.zip https://raw.githubusercontent.com/pyoncord/assets/main/ipa-icons.zip
+          unzip ipa-icons.zip
 
       - name: Extract Values
         run: |
@@ -145,15 +137,7 @@ jobs:
         run: |
           mkdir -p ${{ github.workspace }}/build
           bash -c "$(curl https://raw.githubusercontent.com/asdfzxcvbn/pyzule/main/install-pyzule.sh)"
-          pyzule -t -i discord.ipa -o ${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa -f $(find ${{ github.workspace }} -name 'dev.theos.orion14_*_iphoneos-arm.deb' | head -n 1) ${{ github.workspace }}/${{ env.DEB_FILE_NAME }}
-
-      - name: Patch Discord
-        working-directory: patcher
-        run : |
-          ./patcher \
-            -d ${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa \
-            -o ${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa \
-            -i ./ipa-icons.zip
+          pyzule -n ${{ env.APP_NAME }} -k PyoncordIcon60x60@2x.png -d -t -i discord.ipa -o ${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa -f $(find ${{ github.workspace }} -name 'dev.theos.orion14_*_iphoneos-arm.deb' | head -n 1) ${{ github.workspace }}/${{ env.DEB_FILE_NAME }}
 
       - name: Upload ipa as artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,24 @@ jobs:
 
           release_info=$(gh api --header 'Accept: application/vnd.github+json' repos/${{ github.repository }}/releases/latest)
           status_code=$(echo $release_info | jq -r ".status")
-          if [ "$status_code" != "null" ]; then
+           if [ "$status_code" = "404" ]; then
             echo "No releases found or request failed, status code: $status_code"
             echo "DEB_DOWNLOADED=false" >> $GITHUB_ENV
+            exit 0
+          elif [ "$status_code" = "401" ]; then
+            echo "Unauthorized. Check your GitHub token."
+            exit 0
+          elif [ "$status_code" = "403" ]; then
+            echo "Forbidden. Insufficient permissions."
+            exit 0
+          elif [ "$status_code" = "422" ]; then
+            echo "Unprocessable Entity. Check request payload."
+            exit 0
+          elif [ "${status_code:0:1}" = "5" ]; then
+            echo "Server Error. GitHub API is unavailable."
+            exit 0
+          else
+            echo "Unknown error. Status code: $status_code"
             exit 0
           fi
           release_version=$(echo "$release_info" | jq -r '.assets[] | select(.name | contains("iphoneos-arm.deb")) | .name' | grep -o '_[0-9.]\+_' | tr -d '_')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,32 +24,22 @@ jobs:
 
       - name: Download Tweak
         run: |
-          set -e
+          set +e
 
           release_info=$(gh api --header 'Accept: application/vnd.github+json' repos/${{ github.repository }}/releases/latest)
           status_code=$(echo $release_info | jq -r ".status")
-           if [ "$status_code" = "404" ]; then
+
+          if [ "$status_code" != "null" ]; then
             echo "No releases found or request failed, status code: $status_code"
             echo "DEB_DOWNLOADED=false" >> $GITHUB_ENV
             exit 0
-          elif [ "$status_code" = "401" ]; then
-            echo "Unauthorized. Check your GitHub token."
-            exit 0
-          elif [ "$status_code" = "403" ]; then
-            echo "Forbidden. Insufficient permissions."
-            exit 0
-          elif [ "$status_code" = "422" ]; then
-            echo "Unprocessable Entity. Check request payload."
-            exit 0
-          elif [ "${status_code:0:1}" = "5" ]; then
-            echo "Server Error. GitHub API is unavailable."
-            exit 0
-          else
-            echo "Unknown error. Status code: $status_code"
-            exit 0
           fi
+
+          set -e
+
           release_version=$(echo "$release_info" | jq -r '.assets[] | select(.name | contains("iphoneos-arm.deb")) | .name' | grep -o '_[0-9.]\+_' | tr -d '_')
           control_version=$(grep '^Version:' control | cut -d ' ' -f 2)
+          
           if [ "$release_version" = "$control_version" ]; then
             echo "Versions match. Downloading DEB files..."
             echo "$release_info" | jq -r '.assets[] | select(.name | endswith(".deb")) | .browser_download_url' | xargs -I {} curl -L -O {}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
         run: |
           mkdir -p ${{ github.workspace }}/build
           bash -c "$(curl https://raw.githubusercontent.com/asdfzxcvbn/pyzule/main/install-pyzule.sh)"
-          pyzule -n ${{ env.APP_NAME }} -k PyoncordIcon60x60@2x.png -d -t -i discord.ipa -o ${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa -f $(find ${{ github.workspace }} -name 'dev.theos.orion14_*_iphoneos-arm.deb' | head -n 1) ${{ github.workspace }}/${{ env.DEB_FILE_NAME }}
+          pyzule -n ${{ env.APP_NAME }} -k PyoncordIcon60x60@2x.png -d -i discord.ipa -o ${{ github.workspace }}/build/${{ env.APP_NAME }}.ipa -f $(find ${{ github.workspace }} -name 'dev.theos.orion14_*_iphoneos-arm.deb' | head -n 1) ${{ github.workspace }}/${{ env.DEB_FILE_NAME }}
 
       - name: Upload ipa as artifact
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Builds can be found in the [Releases](https://github.com/pyoncord/BunnyTweak/rel
 ### Jailbroken
 
 1. Install the Orion runtime via your preferred package manager, by adding `https://repo.chariz.com/` to your sources, then finding `Orion Runtime`.
-1. Install Bunny by downloading the appropriate Debian package (or by building your own, see [Building BunnyTweak locally](#building-bunnytweak-locally)) and add it to your package manager. Use the file ending in `arm.deb` for rootful jailbreaks, and the file ending in `arm64.deb` for rootless jailbreaks.
+1. Install Bunny by downloading the appropriate Debian package (or by building your own, see [Building BunnyTweak locally](#building-bunnytweak-locally)) and adding it to your package manager. Use the file ending in `arm.deb` for rootful jailbreaks, and the file ending in `arm64.deb` for rootless jailbreaks.
 
 ### Jailed
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Tweak to inject [Bunny](https://github.com/pyoncord/Bunny) into Discord. Forked [VendettaTweak](https://github.com/vendetta-mod/VendettaTweak), modified to match with [BunnyXposed](https://github.com/pyoncord/BunnyXposed) behavior. There are still slight differences between these two, and this tweak may be missing some loader features.
 
 > [!NOTE]
-> As of right now this tweak does not encompass the some functionalities when running in a jailed environment with a wildcard certificate \
+> As of right now this tweak does not encompass some functionalities when running in a jailed environment with a wildcard certificate \
 > If you value these features sign the application with a local dev certificate:
 > - setAlternateAppIcon does not work, thus breaking dynamic app icons
 > - sharing files to the application/selecting items via the Files app does not work 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Builds can be found in the [Releases](https://github.com/pyoncord/BunnyTweak/rel
 > [!NOTE]
 > TrollStore may display an encryption warning, which you can disregard.
 
-1. Download and install `Bunny.ipa` using your preferred sideloading method.
+1. Download and install [Bunny.ipa](https://github.com/pyoncord/BunnyTweak/releases/latest/download/Bunny.ipa) using your preferred sideloading method.
 
 ## Building BunnyTweak locally
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Builds can be found in the [Releases](https://github.com/pyoncord/BunnyTweak/rel
 
 ### Jailed
 
+<a href="https://tinyurl.com/24zjszuf"><img src="https://i.imgur.com/VKtCePe.png" width="230"></a>
 <a href="https://tinyurl.com/yh455zk6"><img src="https://i.imgur.com/46qhEAv.png" width="230"></a>
 
 1. Download and install `Bunny.ipa` using your preferred sideloading method.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ Builds can be found in the [Releases](https://github.com/pyoncord/BunnyTweak/rel
 
 ### Jailed
 
-<a href="https://tinyurl.com/24zjszuf"><img src="https://i.imgur.com/VKtCePe.png" width="230"></a>
+<a href="https://tinyurl.com/24zjszuf"><img src="https://i.imgur.com/dsbDLK9.png" width="230"></a>
 <a href="https://tinyurl.com/yh455zk6"><img src="https://i.imgur.com/46qhEAv.png" width="230"></a>
+
+> [!NOTE]
+> TrollStore may display an encryption warning, which you can disregard.
 
 1. Download and install `Bunny.ipa` using your preferred sideloading method.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # BunnyTweak
 
-A rootful/rootless tweak to inject [Bunny](https://github.com/pyoncord/Bunny) into Discord. Forked [VendettaTweak](https://github.com/vendetta-mod/VendettaTweak), modified to match with [BunnyXposed](https://github.com/pyoncord/BunnyXposed) behavior. There are still slight differences between these two, and this tweak may be missing some loader features.
+Tweak to inject [Bunny](https://github.com/pyoncord/Bunny) into Discord. Forked [VendettaTweak](https://github.com/vendetta-mod/VendettaTweak), modified to match with [BunnyXposed](https://github.com/pyoncord/BunnyXposed) behavior. There are still slight differences between these two, and this tweak may be missing some loader features.
+
+> [!NOTE]
+> As of right now this tweak does not encompass the some functionalities when running in a jailed environment with a wildcard certificate \
+> If you value these features sign the application with a local dev certificate:
+> - setAlternateAppIcon does not work, thus breaking dynamic app icons
+> - sharing files to the application/selecting items via the Files app does not work 
 
 ## Installation
 
@@ -10,10 +16,10 @@ Builds can be found in the [Releases](https://github.com/pyoncord/BunnyTweak/rel
 > Raw decrypted IPAs which are used to provide prepatched IPAs are sourced from the [Enmity](https://github.com/enmity-mod/) community. These raw decrypted IPAs are also used throughout Enmity related projects such as [enmity-mod/tweak](https://github.com/enmity-mod/tweak/) and [acquitelol/rosiecord](https://github.com/acquitelol/rosiecord).\
 > All credits are attributed to the owner(s) of the raw IPAs.
 
-### Jailbroken (Rootful/Rootless)
+### Jailbroken
 
 1. Install the Orion runtime via your preferred package manager, by adding `https://repo.chariz.com/` to your sources, then finding `Orion Runtime`.
-1. Install Bunny by downloading the appropriate `.deb` file (or by building your own, see [Building BunnyTweak locally](#building-bunnytweak-locally)). Use the file ending in `arm.deb` for rootful jailbreaks, and the file ending in `arm64.deb` for rootless jailbreaks.
+1. Install Bunny by downloading the appropriate Debian package (or by building your own, see [Building BunnyTweak locally](#building-bunnytweak-locally)) and add it to your package manager. Use the file ending in `arm.deb` for rootful jailbreaks, and the file ending in `arm64.deb` for rootless jailbreaks.
 
 ### Jailed
 


### PR DESCRIPTION
- fixes gh cli cancelling the workflow with exit code 1 if no release to download exists
- replaces azule (mostly unmaintained, prone to issues) and patcher (redundant, azule and pyzule can both modify the plist) in favor of pyzule 
- deep link for trollstore and additional info on the tweak limitations 